### PR TITLE
Autoload path inside watcher.php fixed for composer project installation

### DIFF
--- a/src/Filesystem/watcher.php
+++ b/src/Filesystem/watcher.php
@@ -3,7 +3,11 @@
 use seregazhuk\PhpWatcher\Config\WatchList;
 use seregazhuk\PhpWatcher\Watcher\Factory;
 
-require __DIR__ . '/../../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
+	require __DIR__ . '/../../vendor/autoload.php';
+} else {
+	require __DIR__.'/../../../../autoload.php';
+}
 
 $params = array_slice($_SERVER['argv'], 1);
 $watchList = WatchList::fromJson($params[0]);


### PR DESCRIPTION
When installed inside project as composer dependency, watcher.php will try to require autoload.php from wrong location. 