### PR TITLE
Option to prevent running process being wrapped into sh call

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ or using CLI:
 php-watcher server.php --exec php7
 ```
 
+## POSIX Pid and signals
+
+By default, process will be run inside sh wrapper, for [sigchild compatibility](https://reactphp.org/child-process/#sigchild-compatibility). This will prevent signals processing, including SIGTERM on process restart. To prevent this behavior, you may provide `--unwrap` option.
+
+```shell script
+php-watcher server.php --unwrap
+```
+
 # License
 
 MIT [http://rem.mit-license.org](http://rem.mit-license.org)

--- a/src/Config/Builder.php
+++ b/src/Config/Builder.php
@@ -22,6 +22,7 @@ final class Builder
         return new Config(
             $configValues['script'],
             $configValues['executable'],
+            $configValues['unwrap'],
             $configValues['delay'],
             $configValues['arguments'],
             new WatchList(
@@ -66,6 +67,7 @@ final class Builder
             'ignore' => $input->getOption('ignore'),
             'delay' => (float)$input->getOption('delay'),
             'arguments' => $input->getOption('arguments'),
+            'unwrap' => (bool)$input->getOption('unwrap'),
         ];
     }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -6,12 +6,15 @@ final class Config
 {
     private const DEFAULT_PHP_EXECUTABLE = 'php';
     private const DEFAULT_DELAY_IN_SECONDS = 0.25;
+    private const UNWRAP_COMMAND = 'exec';
 
     private $delay;
 
     private $script;
 
     private $phpExecutable;
+
+    private $unwrap;
 
     /**
      * @var string[]
@@ -20,13 +23,14 @@ final class Config
 
     private $watchList;
 
-    public function __construct(string $script, ?string $phpExecutable, ?float $delay, array $arguments, WatchList $watchList)
+    public function __construct(string $script, ?string $phpExecutable, bool $unwrap, ?float $delay, array $arguments, WatchList $watchList)
     {
         $this->script = $script;
         $this->delay = $delay ?: self::DEFAULT_DELAY_IN_SECONDS;
         $this->phpExecutable = $phpExecutable ?: self::DEFAULT_PHP_EXECUTABLE;
         $this->arguments = $arguments;
         $this->watchList = $watchList;
+        $this->unwrap = $unwrap;
     }
 
     public function watchList(): WatchList
@@ -36,7 +40,11 @@ final class Config
 
     public function command(): string
     {
-        return implode(' ', [$this->phpExecutable, $this->script, implode(' ', $this->arguments)]);
+    	$commandComponents = [$this->phpExecutable, $this->script, implode(' ', $this->arguments)];
+    	if ($this->unwrap) {
+    		array_unshift($commandComponents, self::UNWRAP_COMMAND);
+	    }
+        return implode(' ', $commandComponents);
     }
 
     public function delay(): float

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -28,7 +28,8 @@ final class WatcherCommand extends BaseCommand
             ->addOption('exec', null, InputOption::VALUE_OPTIONAL, 'PHP executable')
             ->addOption('delay', null, InputOption::VALUE_OPTIONAL, 'Delaying restart')
             ->addOption('arguments', null, InputOption::VALUE_IS_ARRAY + InputOption::VALUE_OPTIONAL, 'Arguments for the script', [])
-            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Path to config file');
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Path to config file')
+            ->addOption('unwrap', null, InputOption::VALUE_OPTIONAL, 'Unwrap process from sh wrapper', false);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -29,7 +29,7 @@ final class WatcherCommand extends BaseCommand
             ->addOption('delay', null, InputOption::VALUE_OPTIONAL, 'Delaying restart')
             ->addOption('arguments', null, InputOption::VALUE_IS_ARRAY + InputOption::VALUE_OPTIONAL, 'Arguments for the script', [])
             ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Path to config file')
-            ->addOption('unwrap', null, InputOption::VALUE_OPTIONAL, 'Unwrap process from sh wrapper', false);
+            ->addOption('unwrap', null, InputOption::VALUE_NONE, 'Unwrap process from sh wrapper');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/tests/RunScriptTest.php
+++ b/tests/RunScriptTest.php
@@ -30,7 +30,7 @@ final class RunScriptTest extends WatcherTestCase
 	    $this->wait();
 	    $output = $watcher->getOutput();
 
-	    $this->assertStringContainsString("starting `php $scriptToRun`", $output);
+	    $this->assertStringContainsString("starting `exec php $scriptToRun`", $output);
 	    $this->assertStringContainsString('Hello, world', $output);
     }
 }

--- a/tests/RunScriptTest.php
+++ b/tests/RunScriptTest.php
@@ -20,4 +20,17 @@ final class RunScriptTest extends WatcherTestCase
         $this->assertStringContainsString("starting `php $scriptToRun`", $output);
         $this->assertStringContainsString('Hello, world', $output);
     }
+
+    /** @test */
+    public function it_runs_a_php_script_unwrapped(): void
+    {
+	    $scriptToRun = Filesystem::createHelloWorldPHPFile();
+	    $watcher = (new WatcherRunner)->run($scriptToRun, ['--unwrap']);
+
+	    $this->wait();
+	    $output = $watcher->getOutput();
+
+	    $this->assertStringContainsString("starting `php $scriptToRun`", $output);
+	    $this->assertStringContainsString('Hello, world', $output);
+    }
 }


### PR DESCRIPTION
I run into small problem while trying to run watcher on daemonized app, that processes posix signals, including SIGTERM, which is used to restart process. Since process wrapped into sh call, it was unable to correctly shutdown, release tcp port, which lead to defunct sh process on restart (since new process was unable to bind socket) and internally process kept watching that defunct sh process with wrong pid.
I was able to track down this behavior into reactphp/childprocess (and it's documented feature), and added new command-line option to avoid this: --unwrap

Not sure if it's a feature you want to add, tho.)