### PR TITLE
Increase dependency options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 clover.xml
+.phpunit.result.cache
+vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
 language: php
 
-php:
-  - 7.2
-  - 7.3
+jobs:
+  include:
+    - stage: "PHP7.2 - lowest"
+      php: 7.2
+      script:
+        - composer update -n --prefer-dist  --prefer-lowest --no-suggest
+        - composer dump-autoload
+        - php vendor/bin/phpunit
 
-before_script:
-  - composer install --prefer-source --no-interaction
-  - composer dump-autoload
+    - stage: "PHP7.3 - highest"
+      php: 7.3
+      script:
+        - composer update -n --prefer-dist --no-suggest
+        - composer dump-autoload
+        - php vendor/bin/phpunit
 
-script: vendor/bin/phpunit
+    - stage: "PHP7.4 - highest"
+      php: 7.4
+      script:
+        - composer update -n --prefer-dist --no-suggest
+        - composer dump-autoload
+        - php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,15 @@
     ],
     "require": {
         "php": "^7.2",
-        "yosymfony/resource-watcher": "^2.0",
-        "symfony/console": "^4.3",
-        "react/event-loop": "^1.1",
-        "symfony/yaml": "^4.3",
-        "react/child-process": "^0.6.1",
         "ext-json": "*",
         "ext-pcntl": "*",
+        "yosymfony/resource-watcher": "^2.0",
+        "symfony/console": "^4.3 || ^5.0",
+        "react/event-loop": "^1.1",
+        "symfony/yaml": "^4.3 || ^5.0",
+        "react/child-process": "^0.6.1",
+        "react/stream": "^1.0.0",
+        "symfony/finder": "^4.3 || ^5.0",
         "alecrabbit/php-cli-snake": "^0.5"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
+         stopOnFailure="true"
          bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Common">


### PR DESCRIPTION
- Improves test document
    + PHP7.4
    + Lowest dependencies
    + Highest dependencies

- Finder is required by some other libraries, and in lowest version of
  dependencies, the library goes to 2.7. We have forced the library
  to have a minimum dependency of ^4.3